### PR TITLE
feature: add `StreamReader.abort()` method

### DIFF
--- a/__tests__/reader.test.ts
+++ b/__tests__/reader.test.ts
@@ -23,9 +23,9 @@ describe( 'StreamReader', () => {
 
 	it( 'emit \'read\' Event when chunk is received', async () => {
 
-		const stream	= new TransformStream<Buffer>()
+		const stream	= new TransformStream<Buffer, Buffer>()
 		const writer	= stream.writable.getWriter()
-		const reader	= new StreamReader<Buffer>( stream.readable )
+		const reader	= new StreamReader( stream.readable )
 
 		streamData( writer )
 
@@ -40,9 +40,9 @@ describe( 'StreamReader', () => {
 	
 	it( 'emit \'close\' Event when stream writer get closed', async () => {
 
-		const stream	= new TransformStream<Buffer>()
+		const stream	= new TransformStream<Buffer, Buffer>()
 		const writer	= stream.writable.getWriter()
-		const reader	= new StreamReader<Buffer>( stream.readable )
+		const reader	= new StreamReader( stream.readable )
 
 		streamData( writer )
 	
@@ -57,9 +57,9 @@ describe( 'StreamReader', () => {
 
 
 	it( 'skips \'close\' when already closed', async () => {
-		const stream	= new TransformStream<Buffer>()
+		const stream	= new TransformStream<Buffer, Buffer>()
 		const writer	= stream.writable.getWriter()
-		const reader	= new StreamReader<Buffer>( stream.readable )
+		const reader	= new StreamReader( stream.readable )
 
 		streamData( writer )
 	
@@ -68,8 +68,8 @@ describe( 'StreamReader', () => {
 
 		await reader.read()
 
-		reader.close( [] )
-		reader.close( [] )
+		reader.close()
+		reader.close()
 
 		expect( onClose ).toHaveBeenCalledTimes( 1 )
 		expect( onClose ).toHaveBeenCalledWith( expect.any( Array ) )		
@@ -78,9 +78,9 @@ describe( 'StreamReader', () => {
 
 
 	it( 'removes \'read\' and \'close\' listeners on close', async () => {
-		const stream	= new TransformStream<Buffer>()
+		const stream	= new TransformStream<Buffer, Buffer>()
 		const writer	= stream.writable.getWriter()
-		const reader	= new StreamReader<Buffer>( stream.readable )
+		const reader	= new StreamReader( stream.readable )
 
 		streamData( writer )
 	
@@ -97,9 +97,9 @@ describe( 'StreamReader', () => {
 
 
 	it( 'emit \'error\' Event when an Error occures', async () => {
-		const stream	= new TransformStream<Buffer>()
+		const stream	= new TransformStream<Buffer, Buffer>()
 		const writer	= stream.writable.getWriter()
-		const reader	= new StreamReader<Buffer>( stream.readable )
+		const reader	= new StreamReader( stream.readable )
 
 		streamData( writer, true )
 			.catch( error => {
@@ -115,9 +115,9 @@ describe( 'StreamReader', () => {
 
 
 	it( 'throws a new Error when no listener is attached to the \'error\' Event', async () => {
-		const stream	= new TransformStream<Buffer>()
+		const stream	= new TransformStream<Buffer, Buffer>()
 		const writer	= stream.writable.getWriter()
-		const reader	= new StreamReader<Buffer>( stream.readable )
+		const reader	= new StreamReader( stream.readable )
 
 		streamData( writer )
 
@@ -128,9 +128,9 @@ describe( 'StreamReader', () => {
 
 
 	it( 'removes \'read\' and \'close\' listeners when Error occures', async () => {
-		const stream	= new TransformStream<Buffer>()
+		const stream	= new TransformStream<Buffer, Buffer>()
 		const writer	= stream.writable.getWriter()
-		const reader	= new StreamReader<Buffer>( stream.readable )
+		const reader	= new StreamReader( stream.readable )
 
 		streamData( writer, true )
 			.catch( error => {
@@ -164,9 +164,9 @@ describe( 'StreamReader', () => {
 	describe( 'StreamReader.read()', () => {
 		it( 'returns a Promise with an Array of streamed chunks', async () => {
 	
-			const stream		= new TransformStream<Buffer>()
+			const stream		= new TransformStream<Buffer, Buffer>()
 			const writer		= stream.writable.getWriter()
-			const streamReader	= new StreamReader<Buffer>( stream.readable )
+			const streamReader	= new StreamReader( stream.readable )
 	
 			streamData( writer )
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
 		"test:ci:coverage": "pnpm test:ci --coverage",
 		
 		"test:serve-coverage": "http-server ./coverage/lcov-report --gzip true -p 0 -o --silent",
-		"test:coverage:serve": "concurrently --prefix none --kill-others \"pnpm test:coverage\" \"pnpm test:serve-coverage\"",
+		"test:coverage:serve": "concurrently --prefix none --kill-others \"jest --watchAll --verbose --coverage\" \"pnpm test:serve-coverage\"",
 		
 		"test:coverage:jsdom": "JSDOM=true pnpm test:coverage",
 		"test:coverage:jsdom:serve": "JSDOM=true pnpm test:coverage:serve",

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,18 +120,22 @@ export class StreamReader<T = unknown> extends EventEmitter<StreamReaderEvents<T
 	}
 
 
+	
 	/**
-	 * Aborts the {@link ServerSentEvents.writer}.
+	 * Aborts the streaming reader operation.
 	 *
-	 * @param reason - An optional string providing the reason for the abort.
-	 * @returns A new Promise with the current `ServerSentEvents` instance for chaining purposes.
+	 * @param reason - Optional reason for aborting the operation.
+	 * @returns A new Promise that resolves to the current instance after aborting.
+	 *
+	 * @remarks
+	 * This method will cancel the reader, release the lock, emit an 'abort' event, and remove listeners.
 	 */
 	async abort( reason?: string )
 	{
 		if ( this.closed ) return this
 		
 		this.closed		= true
-		const exception	= new DOMException( reason || 'Streming writer aborted.', 'AbortError' )
+		const exception	= new DOMException( reason || 'Streming reader aborted.', 'AbortError' )
 		exception.cause = DOMException.ABORT_ERR
 
 		await this.reader.cancel( exception )

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,26 @@
 import EventEmitter from 'events'
-import type { StreamGenerator, StreamReaderEvents } from './types'
+import type { ReadChunks, StreamGenerator, StreamReaderEvents } from './types'
 
 
 /**
- * A utility class for reading from a `ReadableStream`.
+ * A class for reading data from a `ReadableStream` on demand.
+ * 
  * @template T The type of data being read from the stream.
+ * 
+ * @extends EventEmitter<StreamReaderEvents<T>>
+ * 
+ * @example
+ * ```ts
+ * const response = await fetch('https://example.com/data');
+ * if (response.body) {
+ *   const reader = new StreamReader(response.body);
+ *   for await (const chunk of reader.readChunks()) {
+ *     console.log('Received chunk:', chunk);
+ *   }
+ * }
+ * ```
+ * 
+ * @returns A new instance of `StreamReader`.
  */
 export class StreamReader<T = unknown> extends EventEmitter<StreamReaderEvents<T>>
 {
@@ -12,6 +28,7 @@ export class StreamReader<T = unknown> extends EventEmitter<StreamReaderEvents<T
 	reader: ReadableStreamDefaultReader<T>
 	/** Indicates whether the stream has been closed. */
 	closed: boolean
+	private receivedChunks: ReadChunks<T>
 
 	
 	/**
@@ -22,8 +39,9 @@ export class StreamReader<T = unknown> extends EventEmitter<StreamReaderEvents<T
 	{
 		super( { captureRejections: true } )
 
-		this.reader = stream.getReader()
-		this.closed = false
+		this.reader	= stream.getReader()
+		this.closed	= false
+		this.receivedChunks = []
 	}
 
 
@@ -34,18 +52,19 @@ export class StreamReader<T = unknown> extends EventEmitter<StreamReaderEvents<T
 	 */
 	async read()
 	{
-		const chunks: Awaited<T>[] = []
 		try {
 			for await ( const chunk of this.readChunks() ) {
-				chunks.push( chunk )
+				this.receivedChunks.push( chunk )
 				this.emit( 'read', chunk )
 			}
-			this.close( chunks )
-			return chunks
+			return (
+				this.close()
+					.then( () => this.receivedChunks )
+			)
 		} catch ( error ) {
 			this.error( error as Error )
 		}
-		return chunks
+		return this.receivedChunks
 	}
 
 
@@ -89,18 +108,36 @@ export class StreamReader<T = unknown> extends EventEmitter<StreamReaderEvents<T
 	 * 
 	 * Emits the `close` event.
 	 * 
-	 * @param chunks The stream final chunks array.
 	 * @returns `StreamReader<T>` for chaining purposes.
 	 */
-	close( chunks: Awaited<T>[] )
+	async close()
 	{
 		if ( this.closed ) return this
 		this.closed = true
 		this.reader.releaseLock()
-		this.emit( 'close', chunks )
-		this.removeAllListeners( 'read' )
-		this.removeAllListeners( 'close' )
-		return this
+		this.emit( 'close', this.receivedChunks )
+		return this.removeListeners()
+	}
+
+
+	/**
+	 * Aborts the {@link ServerSentEvents.writer}.
+	 *
+	 * @param reason - An optional string providing the reason for the abort.
+	 * @returns A new Promise with the current `ServerSentEvents` instance for chaining purposes.
+	 */
+	async abort( reason?: string )
+	{
+		if ( this.closed ) return this
+		
+		this.closed		= true
+		const exception	= new DOMException( reason || 'Streming writer aborted.', 'AbortError' )
+		exception.cause = DOMException.ABORT_ERR
+
+		await this.reader.cancel( exception )
+		this.reader.releaseLock()
+		this.emit( 'abort', exception )
+		return this.removeListeners()
 	}
 
 
@@ -116,12 +153,28 @@ export class StreamReader<T = unknown> extends EventEmitter<StreamReaderEvents<T
 	{
 		this.closed = true
 		this.reader.releaseLock()
-		this.removeAllListeners( 'read' )
-		this.removeAllListeners( 'close' )
+		this.removeListeners()
 		if ( ! this.listenerCount( 'error' ) ) {
 			throw error
 		}
 		this.emit( 'error', error )
+		return this
+	}
+
+
+
+
+	/**
+	 * Removes all listeners for the 'read', 'close', and 'abort' events.
+	 *
+	 * @returns The current `StreamReader` instance for chaining.
+	 */
+	private removeListeners()
+	{
+		this.removeAllListeners( 'read' )
+		this.removeAllListeners( 'close' )
+		this.removeAllListeners( 'abort' )
+
 		return this
 	}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,6 @@
+export type ReadChunk<T = unknown> = T | Awaited<T>
+export type ReadChunks<T = unknown> = ReadChunk<T>[]
+
 /**
  * Event types emitted by the StreamReader.
  * @template T The type of data being read from the stream.
@@ -5,16 +8,16 @@
 export type StreamReaderEvents<T = unknown> = {
 	/**
 	 * Emitted when a chunk of data is read from the stream.
-	 * @param {T | Awaited<T>} chunk - The chunk of data read from the stream.
+	 * @param {ReadChunk<T>} chunk - The chunk of data read from the stream.
 	 */
-	read: [ T | Awaited<T> ]
+	read: [ ReadChunk<T> ]
 
 
 	/**
 	 * Emitted when the stream is closed.
-	 * @param {Awaited<T>[]} chunks - An array of chunks read from the stream before it was closed.
+	 * @param {ReadChunks} chunks - An array of chunks read from the stream before it was closed.
 	 */
-	close: [ Awaited<T>[] ]
+	close: [ ReadChunks ]
 
 
 	/**
@@ -22,6 +25,13 @@ export type StreamReaderEvents<T = unknown> = {
 	 * @param {Error} error - The error that occurred during the reading process.
 	 */
 	error: [ Error ]
+
+
+	/**
+	 * Emitted when an error occurs during reading.
+	 * @param {DOMException} error - The error that occurred during the reading process.
+	 */
+	abort: [ DOMException ]
 }
 
 
@@ -42,7 +52,7 @@ export type Listener<
  * Listener for the "read" event.
  * 
  * @template T The type of data being read.
- * @param {T | Awaited<T>} chunk - The chunk of data that was read.
+ * @param {ReadChunk<T>} chunk - The chunk of data that was read.
  */
 export type OnReadEventListener<T = unknown> = Listener<'read', T>
 
@@ -51,9 +61,22 @@ export type OnReadEventListener<T = unknown> = Listener<'read', T>
  * Listener for the "close" event.
  * 
  * @template T The type of data being read.
- * @param {Awaited<T>[]} chunks - An array of chunks read before the stream was closed.
+ * @param {ReadChunk<T>[]} chunks - An array of chunks read before the stream was closed.
  */
 export type OnCloseEventListener<T = unknown> = Listener<'close', T>
+
+
+
+/**
+ * Listener for the "abort" event.
+ * 
+ * This type represents a listener function that is invoked when an 'abort' event occurs.
+ * It is used to define the shape of the listener function that can be registered to handle
+ * such events.
+ * 
+ * @typedef {Listener<'abort'>} OnAbortEventListener
+ */
+export type OnAbortEventListener = Listener<'abort'>
 
 
 /**


### PR DESCRIPTION
It's now possible to abort the reader when no longer needed.