### PR TITLE
feat: add `inMemory` option support

### DIFF
--- a/__tests__/reader.test.ts
+++ b/__tests__/reader.test.ts
@@ -214,6 +214,20 @@ describe( 'StreamReader', () => {
 			} )
 			expect( chunks ).toEqual( defaultChunks )
 		} )
+
+
+		it( 'doen\'t collect in-memory chunks when `inMemory` options is set to `false`', async () => {
+			const stream	= new TransformStream<Buffer, Buffer>()
+			const writer	= stream.writable.getWriter()
+			const reader	= new StreamReader( stream.readable, { inMemory: false } )
+	
+			streamData( { writer } )
+
+			const dataRead = await reader.read()
+
+			expect( dataRead ).toEqual( [] )
+
+		} )
 	} )
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,8 @@ export class StreamReader<I = unknown, O = I> extends EventEmitter<StreamReaderE
 	 * @private
 	 */
 	private receivedChunks: ReadChunks<O>
+
+	private inMemory: Options<I, O>[ 'inMemory' ]
 	private transform: Options<I, O>[ 'transform' ]
 	
 	
@@ -46,6 +48,7 @@ export class StreamReader<I = unknown, O = I> extends EventEmitter<StreamReaderE
 	{
 		super( { captureRejections: true } )
 
+		this.inMemory		= options?.inMemory ?? true
 		this.transform		= options?.transform
 		this.reader			= stream.getReader()
 		this.closed			= false
@@ -70,8 +73,9 @@ export class StreamReader<I = unknown, O = I> extends EventEmitter<StreamReaderE
 						? await this.transform( chunk )
 						: chunk as ReadChunk<O>
 				)
-
-				this.receivedChunks.push( processed )
+				if ( this.inMemory ) {
+					this.receivedChunks.push( processed )
+				}
 				this.emit( 'data', processed )
 			}
 			return (

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export interface Options<I = unknown, O = I>
 {
 	/** A function that transforms a chunk of data. */
     transform?: TransformChunk<I, O>
+	/** Allows to opt-out from in-memory chunks collection. */
+	inMemory?: boolean
 }
 
 


### PR DESCRIPTION
It's now possible to opt-out from in-memory chunks collection